### PR TITLE
FOV scaling fix

### DIFF
--- a/btop/sceneio/camera.py
+++ b/btop/sceneio/camera.py
@@ -71,7 +71,7 @@ class CameraIO(object):
                 # Get fov from camera attributes
                 angle = bpy.context.scene.camera.data.angle
                 ratio = bpy.context.scene.render.resolution_y / bpy.context.scene.render.resolution_x
-                fov = math.degrees(angle * ratio)
+                fov = 2 * math.degrees(math.atan(ratio * math.tan(angle / 2)))
                 camera_line_comps.append('"float fov" {}'.format(fov))
 
         else:


### PR DESCRIPTION
Hi, I'm using btop for my research project (thanks for building it!) and I think there is a small bug in FOV scaling. I was rendering some scenes and found that the output is slightly zoomed in compared to the ground truth. I believe the issue is that when rescaling FOV from horizontal to vertical you need to scale tan(angle), not the angle itself. Follows from:

$ tan(angle_x / 2) = \frac{W}{D}  $
$ tan(angle_y / 2) = \frac{H}{D} $

$ tan(angle_y / 2) = tan(angle_x / 2) \cdot ratio = (\frac{H}{W}) * \frac{W}{D} = \frac{H}{D} $

I made the fix and tested that it works on my scene. Let me know if you need any more info from my side.